### PR TITLE
Better $SIDUSER support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,12 +6,12 @@
 
 myid=${MYID:-9001}
 
-echo "Starting with UID: ${myid}"
-groupadd --gid ${myid} sidgroup
-useradd --shell /bin/bash --uid ${myid} --gid ${myid} --non-unique --no-create-home sid
+echo "Starting as ${SIDUSER} with UID: ${myid}"
+groupadd --gid ${myid} ${SIDUSER}
+useradd --shell /bin/bash --uid ${myid} --gid ${myid} --non-unique --no-create-home ${SIDUSER}
 
-[[ ! -d /home/sid ]] && mkdir /home/sid
-chown -R ${myid}:${myid} /home/sid
-export HOME=/home/sid
+[[ ! -d /home/${SIDUSER} ]] && mkdir /home/${SIDUSER}
+chown -R ${myid}:${myid} /home/${SIDUSER}
+export HOME=/home/${SIDUSER}
 
-exec /usr/local/bin/gosu sid "$@"
+exec /usr/local/bin/gosu ${SIDUSER} "$@"

--- a/files/root/etc/bashrc
+++ b/files/root/etc/bashrc
@@ -7,4 +7,4 @@ cd ~
 
 alias kubectl=oc
 
-PS1="\u \w # "
+PS1="\u@toolkit \w # "


### PR DESCRIPTION
1. Ansible-deployed artifacts are now properly namespaced with $SIDUSER.
1. Toolkit shell prompt is now different from prompt on jump.

**To test (awkward out of necessity)...**
First, note that this _should_ be testing in sync with mysidlabs/jump@1.1.1-siduser.  It doesn't have to be, but it will be confusing for it not to.

```TAG=lab-1.1.1 lab ansible|ocp```